### PR TITLE
changed index().cache timeout calculation

### DIFF
--- a/plugin.video.genesis/modules/libraries/cache.py
+++ b/plugin.video.genesis/modules/libraries/cache.py
@@ -26,7 +26,7 @@ except:
 
 import re
 import hashlib
-import datetime
+import time
 import control
 
 
@@ -57,9 +57,9 @@ def get(function, timeout, *args, **table):
 
         response = eval(match[2].encode('utf-8'))
 
-        t1 = int(re.sub('[^0-9]', '', str(match[3])))
-        t2 = int(datetime.datetime.now().strftime("%Y%m%d%H%M"))
-        update = abs(t2 - t1) >= int(timeout*60)
+        t1 = int(match[3])
+        t2 = int(time.time())
+        update = (abs(t2 - t1) / 3600) >= int(timeout)
         if update == False:
             return response
     except:
@@ -76,7 +76,7 @@ def get(function, timeout, *args, **table):
 
     try:
         r = repr(r)
-        t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+        t = int(time.time())
         dbcur.execute("CREATE TABLE IF NOT EXISTS %s (""func TEXT, ""args TEXT, ""response TEXT, ""added TEXT, ""UNIQUE(func, args)"");" % table)
         dbcur.execute("DELETE FROM %s WHERE func = '%s' AND args = '%s'" % (table, f, a))
         dbcur.execute("INSERT INTO %s Values (?, ?, ?, ?)" % table, (f, a, r, t))
@@ -100,4 +100,3 @@ def clear(table):
         dbcon.commit()
     except:
         pass
-

--- a/plugin.video.genesis/modules/libraries/cachemeta.py
+++ b/plugin.video.genesis/modules/libraries/cachemeta.py
@@ -26,7 +26,7 @@ except:
 
 import re
 import hashlib
-import datetime
+import time
 import control
 
 
@@ -52,9 +52,9 @@ def get(function, timeout, *args):
 
         response = eval(match[2].encode('utf-8'))
 
-        t1 = int(re.sub('[^0-9]', '', str(match[3])))
-        t2 = int(datetime.datetime.now().strftime("%Y%m%d%H%M"))
-        update = abs(t2 - t1) >= int(timeout*60)
+        t1 = int(match[3])
+        t2 = int(time.time())
+        update = (abs(t2 - t1) / 3600) >= int(timeout)
         if update == False:
             return response
     except:
@@ -73,7 +73,7 @@ def get(function, timeout, *args):
         insert = True
         if r['cover_url'] == '' or r['backdrop_url'] == '': insert = False
         r = repr(r)
-        t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+        t = int(time.time())
         dbcur.execute("CREATE TABLE IF NOT EXISTS rel_list (""func TEXT, ""args TEXT, ""response TEXT, ""added TEXT, ""UNIQUE(func, args)"");")
         dbcur.execute("DELETE FROM rel_list WHERE func = '%s' AND args = '%s'" % (f, a))
         if insert == True: dbcur.execute("INSERT INTO rel_list Values (?, ?, ?, ?)", (f, a, r, t))
@@ -85,4 +85,3 @@ def get(function, timeout, *args):
         return eval(r.encode('utf-8'))
     except:
         pass
-

--- a/plugin.video.genesis/modules/v4/__init__.py
+++ b/plugin.video.genesis/modules/v4/__init__.py
@@ -220,9 +220,9 @@ class index:
 
             response = eval(match[2].encode('utf-8'))
 
-            t1 = int(re.sub('[^0-9]', '', str(match[3])))
-            t2 = int(datetime.datetime.now().strftime("%Y%m%d%H%M"))
-            update = abs(t2 - t1) >= int(timeout*60)
+            t1 = int(match[3])
+            t2 = int(time.time())
+            update = (abs(t2 - t1) / 3600) >= int(timeout)
             if update == False:
                 return response
         except:
@@ -239,7 +239,7 @@ class index:
 
         try:
             r = repr(r)
-            t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+            t = int(time.time())
             dbcur.execute("CREATE TABLE IF NOT EXISTS rel_list (""func TEXT, ""args TEXT, ""response TEXT, ""added TEXT, ""UNIQUE(func, args)"");")
             dbcur.execute("DELETE FROM rel_list WHERE func = '%s' AND args = '%s'" % (f, a))
             dbcur.execute("INSERT INTO rel_list Values (?, ?, ?, ?)", (f, a, r, t))
@@ -613,7 +613,7 @@ class index:
                 if not (getSetting("trakt_user") == '' or getSetting("trakt_password") == ''):
                     cm.append((language(30419).encode("utf-8"), 'RunPlugin(%s?action=trakt_tv_manager&name=%s&tvdb=%s)' % (sys.argv[0], systitle, systvdb)))
                 if action == 'shows_favourites':
-                    cm.append((language(30406).encode("utf-8"), 'RunPlugin(%s?action=favourite_delete&imdb=%s)' % (sys.argv[0], sysimdb))) 
+                    cm.append((language(30406).encode("utf-8"), 'RunPlugin(%s?action=favourite_delete&imdb=%s)' % (sys.argv[0], sysimdb)))
                 elif action.startswith('shows_search'):
                     cm.append((language(30405).encode("utf-8"), 'RunPlugin(%s?action=favourite_tv_from_search&imdb=%s&name=%s&year=%s&image=%s)' % (sys.argv[0], sysimdb, systitle, sysyear, sysimage)))
                 else:
@@ -1150,7 +1150,7 @@ class contextMenu:
             except: pass
             try:
 				if not 'ftp://' in folder: raise Exception()
-				from ftplib import FTP		
+				from ftplib import FTP
 				ftparg = re.compile('ftp://(.+?):(.+?)@(.+?):?(\d+)?/(.+/?)').findall(folder)
 				ftp = FTP(ftparg[0][2],ftparg[0][0],ftparg[0][1])
 				try: ftp.cwd(ftparg[0][4])
@@ -1287,7 +1287,7 @@ class contextMenu:
             except: pass
             try:
 				if not 'ftp://' in folder: raise Exception()
-				from ftplib import FTP		
+				from ftplib import FTP
 				ftparg = re.compile('ftp://(.+?):(.+?)@(.+?):?(\d+)?/(.+/?)').findall(folder)
 				ftp = FTP(ftparg[0][2],ftparg[0][0],ftparg[0][1])
 				try: ftp.cwd(ftparg[0][4])
@@ -1303,7 +1303,7 @@ class contextMenu:
             except: pass
             try:
 				if not 'ftp://' in folder: raise Exception()
-				from ftplib import FTP		
+				from ftplib import FTP
 				ftparg = re.compile('ftp://(.+?):(.+?)@(.+?):?(\d+)?/(.+/?)').findall(folder)
 				ftp = FTP(ftparg[0][2],ftparg[0][0],ftparg[0][1])
 				try: ftp.cwd(ftparg[0][4])
@@ -2080,7 +2080,7 @@ class channels:
         self.sky_programme_link = 'http://tv.sky.com/programme/channel/%s/%s/%s.json'
 
     def movies(self):
-        channelDict = [('01', 'Sky Premiere', '1409'), ('02', 'Sky Premiere +1', '1823'), ('03', 'Sky Showcase', '1814'), ('04', 'Sky Greats', '1815'), ('05', 'Sky Disney', '1838'), ('06', 'Sky Family', '1808'), ('07', 'Sky Action', '1001'), ('08', 'Sky Comedy', '1002'), ('09', 'Sky Crime', '1818'), ('10', 'Sky Drama', '1816'), ('11', 'Sky Sci Fi', '1807'), ('12', 'Sky Select', '1811'), ('13', 'Film4', '1627'), ('14', 'TCM', '5605')] 
+        channelDict = [('01', 'Sky Premiere', '1409'), ('02', 'Sky Premiere +1', '1823'), ('03', 'Sky Showcase', '1814'), ('04', 'Sky Greats', '1815'), ('05', 'Sky Disney', '1838'), ('06', 'Sky Family', '1808'), ('07', 'Sky Action', '1001'), ('08', 'Sky Comedy', '1002'), ('09', 'Sky Crime', '1818'), ('10', 'Sky Drama', '1816'), ('11', 'Sky Sci Fi', '1807'), ('12', 'Sky Select', '1811'), ('13', 'Film4', '1627'), ('14', 'TCM', '5605')]
 
         threads = []
         for i in channelDict: threads.append(Thread(self.sky_list, i[0], i[1], i[2]))
@@ -3805,7 +3805,7 @@ class seasons:
             show_alt = common.parseDOM(result, "SeriesName")[0]
             dupe = re.compile('[***]Duplicate (\d*)[***]').findall(show)
             if len(dupe) > 0: show = show_alt
-            if show == '': raise Exception() 
+            if show == '': raise Exception()
             if show_alt == '': show_alt = show
             show_alt = common.replaceHTMLCodes(show_alt)
             show_alt = show_alt.encode('utf-8')
@@ -4467,4 +4467,3 @@ class episodes:
             return self.list
         except:
             return
-


### PR DESCRIPTION
While I was doing #37 I looked at index.cache() to understand what "timeout" meant, I noticed that your calculation was a bit weird:

            t1 = int(re.sub('[^0-9]', '', str(match[3])))
            t2 = int(datetime.datetime.now().strftime("%Y%m%d%H%M"))
            update = abs(t2 - t1) >= int(timeout*60)

If the timeout is 24h and cache is refresh at 11PM, one hour later `update` will be true when it shouldn't it (in my understanding).

So I propose using unix timestamp which has the side-advantage of a impossible-to-notice performance improvament (by removing the string formatting):

```
import datetime
import re
import time
import timeit


def old():
    timeout = 1
    t1 = int(re.sub('[^0-9]', '', str('2015-09-12 11:22')))
    t2 = int(datetime.datetime.now().strftime("%Y%m%d%H%M"))
    return abs(t2 - t1) >= int(timeout * 60)


def new():
    timeout = 1
    t1 = int('1436522674')
    t2 = int(time.time())
    return abs((t2 - t1) / 3600) >= int(timeout)

print 'strftime', timeit.timeit(old, number=100000)
print 'unixtime', timeit.timeit(new, number=100000)
```
```
strftime 0.597686052322
unixtime 0.0609300136566
```
