### PR TITLE
Prevent premature watched flag

### DIFF
--- a/plugin.video.genesis/resources/lib/libraries/player.py
+++ b/plugin.video.genesis/resources/lib/libraries/player.py
@@ -218,12 +218,6 @@ class player(xbmc.Player):
 
 
     def onPlayBackEnded(self):
-        try:
-            bookmarks.deleteBookmark(self.name, self.imdb)
-        except:
-            pass
-        try:
-            self.setWatchedStatus()
-        except:
-            pass
+        self.onPlayBackStopped()
+
 


### PR DESCRIPTION
Sometimes the source fails and the video will stop and call onPlayBackEnded() even though the video is only half way through playback. This would of course change the watched state and not store a resume point before this proposed change.